### PR TITLE
Restructure docs and add contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,54 @@
 # Velkommen!
 
-## Installasjonsinstrukser
+Dette repoet inneholder kildekoden til [Studentersamfundets Interne Teaters hjemmsider](https://sit.samfundet.no).
+Under følger en guide for hvordan du kan bidra til videre utvikling av siden.
 
-Vi bruker `pipenv` for å holde styr på hvilke Python-pakker vi trenger. For å lære hvordan du skaffer deg dette kan du se [dokumentasjonen](https://pipenv.pypa.io/en/latest/install/#installing-pipenv) eller spørre om hjelp på Slack-kanalen `#techsupport`.
+Om du trenger hjelp til å installere pakkene du trenger, se [installasjonsinstruksene](/docs/installing_packages.md)
 
-Etter at du har installert `pipenv` skaffer du deg Django på denne måten: Åpne terminalen din (Terminal/iTerm/Git Bash/det du foretrekker) og pass på at du er i korrekt mappe:
+Om du har noen spørsmål, ikke nøl med å [ta kontakt](mailto:sit-web@samfundet.no).
+
+## Hvordan bidra til siden
+
+Om du ikke vet hvordan Git og Github fungerer anbefaler vi at du aller først bruker litt tid på å lære deg dette. En fin ressurs er [GitHubs egne guider](https://guides.github.com/).
+
+Om du skal gjøre en ikke-triviell endring må du aller først klone repoet til din egen maskin.
 
 ```bash
-$ pwd
-/dine-mapper/sit-web
+$ git clone https://github.com/Studentersamfundets-Interne-Teater/sit-web.git
+$ cd sit-web
 ```
 
-Deretter installerer du pakkene du trenger ganske enkelt:
+Koden som ligger på `master` skal alltid være den som er i produksjon. Vi har derfor en egen branch som heter `develop` som skal brukes som utgangspunkt for alle endringer. Vi gjør flere mindre endringer på `develop`, og etter at disse er testet og vi er fornøyd med hvordan ting fungerer her vil vi deretter hente disse inn i `master`.
 
-```shell
-$ pipenv install
-Installing dependencies from Pipfile.lock (a6086c)…
-To activate this project's virtualenv, run pipenv shell.
-Alternatively, run a command inside the virtualenv with pipenv run.
+Neste trinn er derfor å hente ned de ulike branchene fra GitHub, bytte til develop, og deretter åpne en ny gren derfra. Om du for eksempel skal designe en ny header kunne du kalt denne grenen `new-header`. Da blir flyten som følger:
+
+```bash
+$ git fetch
+$ git checkout develop
+Branch 'develop' set up to track remote branch 'develop' from 'origin'.
+Switched to a new branch 'develop'
+$ git checkout -b new-header
+Switched to a new branch 'new-header'
 ```
 
-Dette oppretter et virtuelt Python-miljø på maskinen din som sørger for at Django ikke krangler med noen andre pakker du har installert fra før. Du må aktivere dette miljøet før du kan kjøre prosjektet:
-
-```shell
-$ pipenv shell
-Launching subshell in virtual environment…
+Deretter kan du starte med å gjennomføre endringen din.
+Pass på å commite ofte, og skriv beskrivende commit-meldinger som beskriver endringen din på en måte som gjør at andre kan forstå hva du har endret. Commit-meldingene skal helst ikke være lenger enn 50 tegn, og skries i imperativ (kommanderende) form. Eksempler kan være
+```bash
+$ git commit -m "Change header logo to SVG format"
+$ git commit -m "Reorder header items"
+$ git commit -m "Fix overlapping icons in header in mobile layout"
 ```
 
-Deretter kan du starte Django sin utviklingsserver og se prosjektet i sin nåværende tilstand:
-
-```shell
-$ python sit/manage.py runserver
-Django version 3.0.8, using settings 'sit.settings'
-Starting development server at http://127.0.0.1:8000/
-Quit the server with CONTROL-C.
+Etter du har gjort alle endringene dine, dytt dem opp til GitHub:
+```bash
+$ git push -u origin new-header
 ```
+Her må `new-header` erstattes med navnet du valgte til din branch. Flagget `-u` står for `upstream`, og sikrer at dersom du vil dytte flere endringer eller hente eventuelle andre endringer som noen andre gjør på din gren, så kan i fremtiden slippe unna med å skrive kun `git pull` eller `git push`.
 
-![Skjermbilde av Django-serverens velkomstside](./assets/runserver-screenshot.png)
+Etter å ha skrevet denne kommandoen får du et svar med en link du kan trykke på for å åpne en pull request. Gå til denne, og pass på at du velger `develop` som branch slik at du ikke åpner en pull request rett i prod. For mer informasjon om hvordan dette foregår, se gjerne [GitHub sin egen dokumentasjon](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+
+Husk å skrive en kort tekst om hvilke endringer du har gjort, og hvorfor.
+
+Etter at du har åpnet en Pull Request må den godkjennes av noen med skrivetilgang i repoet. De vil hente dine endringer ned til sin egen maskin, gå gjennom dem, og se at alt fungerer som det skal. Det kan også hende de vil be om små endringer. Når alt ser bra ut vil de godkjenne Pull Requesten, og du kan trykke på den grønne «Merge»-knappen.
+
+Takk for interessen for siden vår!

--- a/docs/installing_packages.md
+++ b/docs/installing_packages.md
@@ -1,0 +1,37 @@
+## Installasjonsinstrukser
+
+Vi bruker `pipenv` for å holde styr på hvilke Python-pakker vi trenger. For å lære hvordan du skaffer deg dette kan du se [dokumentasjonen](https://pipenv.pypa.io/en/latest/install/#installing-pipenv) eller spørre om hjelp på Slack-kanalen `#techsupport`.
+
+Etter at du har installert `pipenv` skaffer du deg Django på denne måten: Åpne terminalen din (Terminal/iTerm/Git Bash/det du foretrekker) og pass på at du er i korrekt mappe:
+
+```bash
+$ pwd
+/dine-mapper/sit-web
+```
+
+Deretter installerer du pakkene du trenger ganske enkelt:
+
+```shell
+$ pipenv install
+Installing dependencies from Pipfile.lock (a6086c)…
+To activate this project's virtualenv, run pipenv shell.
+Alternatively, run a command inside the virtualenv with pipenv run.
+```
+
+Dette oppretter et virtuelt Python-miljø på maskinen din som sørger for at Django ikke krangler med noen andre pakker du har installert fra før. Du må aktivere dette miljøet før du kan kjøre prosjektet:
+
+```shell
+$ pipenv shell
+Launching subshell in virtual environment…
+```
+
+Deretter kan du starte Django sin utviklingsserver og se prosjektet i sin nåværende tilstand:
+
+```shell
+$ python sit/manage.py runserver
+Django version 3.0.8, using settings 'sit.settings'
+Starting development server at http://127.0.0.1:8000/
+Quit the server with CONTROL-C.
+```
+
+Du kan se siden i sin nåværende form ved å navigere til http://127.0.0.1:8000/ eller [localhost:8000](http://127.0.0.1:8000/).


### PR DESCRIPTION
Flytter instruksene for å få tak i de rette Python-pakkene inn i en egen fil, og bruker heller `README.md` til å komme med generell informasjon om hvordan arbeidsflyten fungerer.

Dette er kun et forslag. Tar gjerne imot kommentarerer til forbedringer eller endringer dersom dere ønsker å gjøre det på en annen måte :tada: