### PR TITLE
Collapse-JS bugfixes

### DIFF
--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -1,16 +1,23 @@
 var categories = document.getElementsByClassName("production-categories");
 var i;
+const visiblePadding = "15px 0";
 
 if (window.innerWidth < 1024) {
-  for (i = 0; i < categories.length; i++) {
-    categories[i].addEventListener("click", function() {
+  for (category of categories) {
+    category.nextElementSibling.style.visibility = "hidden";
+    category.addEventListener("click", function() {
       this.classList.toggle("active");
       var content = this.nextElementSibling;
-      if (content.style.maxHeight){
-        content.style.maxHeight = null;
+      var contentIsActive = this.classList.contains("active");
+      content.style.maxHeight = contentIsActive ? content.scrollHeight + "px" : null;
+      if (contentIsActive) {
+        content.style.visibility = "visible";
       } else {
-        content.style.maxHeight = content.scrollHeight + "px";
-      } 
+        // Wait 200 ms before hiding content for smoother UX
+        window.setTimeout(() => {
+          content.style.visibility = "hidden";
+        }, 200);
+      }
     });
   }
 }
@@ -20,17 +27,19 @@ else {
   categories[0].style.fontWeight = "600";
   for (i = 0; i < categories.length; i++) {
     categories[i].addEventListener("click", function() {
-      this.classList.toggle("active");
+      this.classList.add("active");
       var content = this.nextElementSibling; 
-      
-      this.style.fontWeight = "600"; //Bold font when active
-      for (j = 0; j<categories.length; j++) {
-        if (categories[j].nextElementSibling !== content) {
-          categories[j].nextElementSibling.style.display = "none";
-          categories[j].style.fontWeight = "400"; //Normal font weight
+      this.style.fontWeight = "600"; // Bold font when active
+      for (category of categories) {
+        if (category.nextElementSibling !== content) {
+          category.nextElementSibling.style.display = "none";
+          category.style.fontWeight = "400"; // Normal font weight
+          category.classList.remove("active");
         }
       }      
       content.style.display = "block";
+      content.style.maxHeight = "100%";
+      console.log(content);
     });
   }
   

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -1,4 +1,5 @@
 var categories = document.getElementsByClassName("production-categories");
+var parent = document.getElementById("production-info");
 
 if (window.innerWidth < 1024) {
   for (category of categories) {
@@ -36,6 +37,8 @@ if (window.innerWidth < 1024) {
       }      
       content.style.display = "block";
       content.style.maxHeight = content.scrollHeight + "px";
+
+      parent.style.height = content.scrollHeight + "px";
     });
   }
   

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -22,7 +22,7 @@ if (window.innerWidth < 1024) {
 } else {
   categories[0].nextElementSibling.style.display = "block";
   categories[0].style.fontWeight = "600";
-  for (i = 0; i < categories.length; i++) {
+  for (var i = 0; i < categories.length; i++) {
     categories[i].addEventListener("click", function() {
       this.classList.add("active");
       var content = this.nextElementSibling; 

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -37,7 +37,6 @@ else {
       }      
       content.style.display = "block";
       content.style.maxHeight = "100%";
-      console.log(content);
     });
   }
   

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -7,12 +7,13 @@ if (window.innerWidth < 1024) {
       this.classList.toggle("active");
       var content = this.nextElementSibling;
       var contentIsActive = this.classList.contains("active");
-      content.style.maxHeight = contentIsActive ? content.scrollHeight + "px" : null;
       if (contentIsActive) {
+        content.style.maxHeight = content.scrollHeight + "px";
         content.style.visibility = "visible";
       } else {
         // Wait 200 ms before hiding content for smoother UX
         window.setTimeout(() => {
+          content.style.maxHeight = null;
           content.style.visibility = "hidden";
         }, 200);
       }

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -37,7 +37,7 @@ else {
         }
       }      
       content.style.display = "block";
-      content.style.maxHeight = "100%";
+      content.style.maxHeight = content.scrollHeight + "px";
     });
   }
   

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -1,6 +1,5 @@
 var categories = document.getElementsByClassName("production-categories");
 var i;
-const visiblePadding = "15px 0";
 
 if (window.innerWidth < 1024) {
   for (category of categories) {

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -19,9 +19,7 @@ if (window.innerWidth < 1024) {
       }
     });
   }
-}
-
-else {
+} else {
   categories[0].nextElementSibling.style.display = "block";
   categories[0].style.fontWeight = "600";
   for (i = 0; i < categories.length; i++) {

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -1,5 +1,4 @@
 var categories = document.getElementsByClassName("production-categories");
-var i;
 
 if (window.innerWidth < 1024) {
   for (category of categories) {

--- a/SITnett/graphics/style.css
+++ b/SITnett/graphics/style.css
@@ -745,6 +745,7 @@ select{
 		width: 80%;
 		max-width: 1200px;
 		margin: auto;
+		min-height: 320px;
 	}
 	.production-categories {
 		width: 25%;
@@ -753,7 +754,7 @@ select{
 	}
 	.production-category-content {
 		position: absolute;
-		height: 100%;
+		height: min-content;
 		top: 0;
 		
 		display: none;

--- a/SITnett/templates/produksjoner/produksjon_info.html
+++ b/SITnett/templates/produksjoner/produksjon_info.html
@@ -60,7 +60,7 @@
 		{% endif %}
 	</div>
 	
-	<section class="production-information">
+	<section class="production-information" id="production-info">
 		<div class="firstDivider"></div>
 		<a class="production-categories">Beskrivelse</a>
 		<div class="production-category-content">
@@ -188,4 +188,5 @@
 	{% endblock produksjon_nav %}
 	
 	<script src="{% static 'collapsible.js' %}"></script>
+	<script src="{% static 'image_gallery.js' %}"></script>
 {% endblock innhold %}


### PR DESCRIPTION
JS-filen for å vise og skjule felter i detaljvisningen til produksjonene hadde noen småfeil som nå forhåpentligvis skal være rettet opp:

- På grunn av padding var innhold synlig selv om det ikke var hentet frem. Dette løses ved å iterere over alle kategoriene og sette `visibility: hidden`.
- På desktop ble `"active"` lagt til som en klasse hver gang man trykket på en link, også om man trykket på den samme to ganger på rad. Ikke så farlig siden det ser ut som om denne klassen enn så lenge ikke gjør noe, men greit at det virker som den skal i tilfelle vi vil bruke den i fremtiden.
- På desktop ble `max-height` aldri endret fra å være 0, så innholdet forble skjult selv om man trykket på den tilhørende overskriften.

### Ting som kan være verdt å komme tilbake til

- Endre logikken til å være mer konsekvent for mobil og desktop. Per nå er breakpoint hardkodet, som ikke er ideelt om vi vil endre det senere.
- Endre logikken til å være mindre avhengig av DOM-strukturen. Om denne endres i fremtiden knekker siden uten at det er åpenbart hvorfor.