### PR TITLE
Fiks 500 server error når sit-intern vil se på produksjoner

### DIFF
--- a/SITnett/SITnett/views.py
+++ b/SITnett/SITnett/views.py
@@ -334,9 +334,13 @@ def view_produksjon_info(request, pid):
     if not features.TOGGLE_PRODUKSJONER:
         return redirect('hoved')
     produksjon = get_object_or_404(models.Produksjon, id=pid)
+    try:
+        user_medlem = models.Medlem.objects.get(brukerkonto=request.user)
+    except models.Medlem.DoesNotExist:
+        user_medlem = None
     if request.user.has_perm('SITdata.change_produksjon'):
         access = 'admin'
-    elif request.user.is_authenticated \
+    elif user_medlem is not None and request.user.is_authenticated \
             and request.user.medlem.erfaringer.all() & produksjon.erfaringer.filter(verv__tittel="produsent"):
         access = 'own'
     else:


### PR DESCRIPTION
Når serveren får en request til å se detaljer om produksjon sjekker den først om den innloggede brukeren er en admin. Om dette ikke er tilfelle sjekker den deretter om brukeren er tilknyttet produksjonen gjennom et verv. Det den derimot _ikke_ sjekket, og grunnen til at alt kræsjet, er at den ikke verifiserte at den innloggede brukeren er tilknyttet et SIT-medlem som ligger i databasen. Dermed førte linjen `request.user.medlem.erfaringer.all()` til en serverfeil.

Fiksen er ganske enkelt å sjekke om det eksisterer et medlem med et brukernavn som matcher den innloggede brukeren.