### PR TITLE
Fiks høyde på produksjonsinfo

### DIFF
--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -1,56 +1,60 @@
-var categories = document.getElementsByClassName("production-categories");
-var productionInfo = document.getElementById("production-info");
+function _setUpCollapsible() {
+  var categories = document.getElementsByClassName("production-categories");
+  var productionInfo = document.getElementById("production-info");
 
-if (window.innerWidth < 1024) {
-  for (category of categories) {
-    category.nextElementSibling.style.visibility = "hidden";
-    category.addEventListener("click", function() {
-      this.classList.toggle("active");
-      var content = this.nextElementSibling;
-      var contentIsActive = this.classList.contains("active");
-      if (contentIsActive) {
-        content.style.maxHeight = content.scrollHeight + "px";
-        content.style.visibility = "visible";
-      } else {
-        // Wait 200 ms before hiding content for smoother UX
-        window.setTimeout(() => {
-          content.style.maxHeight = null;
-          content.style.visibility = "hidden";
-        }, 200);
-      }
-    });
-  }
-} else {
-  var emtpyHeight = productionInfo.getBoundingClientRect().height;
-  categories[0].nextElementSibling.style.display = "block";
-  var initialHeight = categories[0].nextElementSibling.scrollHeight;
-  categories[0].nextElementSibling.style.maxHeight = initialHeight + "px";
-  console.log(initialHeight);
-  if (initialHeight > emtpyHeight) {
-    productionInfo.style.height = initialHeight + "px";
-  }
-  categories[0].style.fontWeight = "600";
-  for (var i = 0; i < categories.length; i++) {
-    categories[i].addEventListener("click", function(e) {
-      e.target.classList.add("active");
-      var content = e.target.nextElementSibling;
-      e.target.style.fontWeight = "600"; // Bold font when active
-      for (category of categories) {
-        if (category.nextElementSibling !== content) {
-          category.nextElementSibling.style.display = "none";
-          category.style.fontWeight = "400"; // Normal font weight
-          category.classList.remove("active");
+  if (window.innerWidth < 1024) {
+    for (category of categories) {
+      category.nextElementSibling.style.visibility = "hidden";
+      category.addEventListener("click", function () {
+        this.classList.toggle("active");
+        var content = this.nextElementSibling;
+        var contentIsActive = this.classList.contains("active");
+        if (contentIsActive) {
+          content.style.maxHeight = content.scrollHeight + "px";
+          content.style.visibility = "visible";
+        } else {
+          // Wait 200 ms before hiding content for smoother UX
+          window.setTimeout(() => {
+            content.style.maxHeight = null;
+            content.style.visibility = "hidden";
+          }, 200);
         }
-      }
-      content.style.display = "block";
-      content.style.maxHeight = content.scrollHeight + "px";
-      console.log(content.scrollHeight);
-      if (content.scrollHeight > emtpyHeight) {
-        console.log("Here")
-        productionInfo.style.height = content.scrollHeight + "px";
-      } else {
-        productionInfo.style.height = null;
-      }
-    });
+      });
+    }
+  } else {
+    var emtpyHeight = productionInfo.getBoundingClientRect().height;
+    categories[0].nextElementSibling.style.display = "block";
+    var initialHeight = categories[0].nextElementSibling.scrollHeight;
+    categories[0].nextElementSibling.style.maxHeight = initialHeight + "px";
+    console.log(initialHeight);
+    if (initialHeight > emtpyHeight) {
+      productionInfo.style.height = initialHeight + "px";
+    }
+    categories[0].style.fontWeight = "600";
+    for (var i = 0; i < categories.length; i++) {
+      categories[i].addEventListener("click", function (e) {
+        e.target.classList.add("active");
+        var content = e.target.nextElementSibling;
+        e.target.style.fontWeight = "600"; // Bold font when active
+        for (category of categories) {
+          if (category.nextElementSibling !== content) {
+            category.nextElementSibling.style.display = "none";
+            category.style.fontWeight = "400"; // Normal font weight
+            category.classList.remove("active");
+          }
+        }
+        content.style.display = "block";
+        content.style.maxHeight = content.scrollHeight + "px";
+        console.log(content.scrollHeight);
+        if (content.scrollHeight > emtpyHeight) {
+          console.log("Here");
+          productionInfo.style.height = content.scrollHeight + "px";
+        } else {
+          productionInfo.style.height = null;
+        }
+      });
+    }
   }
 }
+
+window.addEventListener('load', _setUpCollapsible);

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -25,7 +25,9 @@ if (window.innerWidth < 1024) {
   categories[0].nextElementSibling.style.display = "block";
   var initialHeight = categories[0].nextElementSibling.scrollHeight + "px";
   categories[0].nextElementSibling.style.maxHeight = initialHeight;
-  productionInfo.style.height = initialHeight;
+  if (initialHeight > emtpyHeight) {
+    productionInfo.style.height = initialHeight;
+  }
   categories[0].style.fontWeight = "600";
   for (var i = 0; i < categories.length; i++) {
     categories[i].addEventListener("click", function(e) {

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -1,5 +1,5 @@
 var categories = document.getElementsByClassName("production-categories");
-var parent = document.getElementById("production-info");
+var productionInfo = document.getElementById("production-info");
 
 if (window.innerWidth < 1024) {
   for (category of categories) {
@@ -21,28 +21,33 @@ if (window.innerWidth < 1024) {
     });
   }
 } else {
+  var emtpyHeight = productionInfo.getBoundingClientRect().height;
   categories[0].nextElementSibling.style.display = "block";
   var initialHeight = categories[0].nextElementSibling.scrollHeight + "px";
   categories[0].nextElementSibling.style.maxHeight = initialHeight;
-  parent.style.height = initialHeight;
+  productionInfo.style.height = initialHeight;
   categories[0].style.fontWeight = "600";
   for (var i = 0; i < categories.length; i++) {
-    categories[i].addEventListener("click", function() {
-      this.classList.add("active");
-      var content = this.nextElementSibling; 
-      this.style.fontWeight = "600"; // Bold font when active
+    categories[i].addEventListener("click", function(e) {
+      e.target.classList.add("active");
+      var content = e.target.nextElementSibling;
+      e.target.style.fontWeight = "600"; // Bold font when active
       for (category of categories) {
         if (category.nextElementSibling !== content) {
           category.nextElementSibling.style.display = "none";
           category.style.fontWeight = "400"; // Normal font weight
           category.classList.remove("active");
         }
-      }      
+      }
       content.style.display = "block";
       content.style.maxHeight = content.scrollHeight + "px";
-
-      parent.style.height = content.scrollHeight + "px";
+      console.log(content.scrollHeight);
+      if (content.scrollHeight > emtpyHeight) {
+        console.log("Here")
+        productionInfo.style.height = content.scrollHeight + "px";
+      } else {
+        productionInfo.style.height = null;
+      }
     });
   }
-  
 }

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -23,10 +23,11 @@ if (window.innerWidth < 1024) {
 } else {
   var emtpyHeight = productionInfo.getBoundingClientRect().height;
   categories[0].nextElementSibling.style.display = "block";
-  var initialHeight = categories[0].nextElementSibling.scrollHeight + "px";
-  categories[0].nextElementSibling.style.maxHeight = initialHeight;
+  var initialHeight = categories[0].nextElementSibling.scrollHeight;
+  categories[0].nextElementSibling.style.maxHeight = initialHeight + "px";
+  console.log(initialHeight);
   if (initialHeight > emtpyHeight) {
-    productionInfo.style.height = initialHeight;
+    productionInfo.style.height = initialHeight + "px";
   }
   categories[0].style.fontWeight = "600";
   for (var i = 0; i < categories.length; i++) {

--- a/SITnett/graphics/collapsible.js
+++ b/SITnett/graphics/collapsible.js
@@ -22,7 +22,9 @@ if (window.innerWidth < 1024) {
   }
 } else {
   categories[0].nextElementSibling.style.display = "block";
-  categories[0].nextElementSibling.style.maxHeight = categories[0].nextElementSibling.scrollHeight + "px";
+  var initialHeight = categories[0].nextElementSibling.scrollHeight + "px";
+  categories[0].nextElementSibling.style.maxHeight = initialHeight;
+  parent.style.height = initialHeight;
   categories[0].style.fontWeight = "600";
   for (var i = 0; i < categories.length; i++) {
     categories[i].addEventListener("click", function() {

--- a/SITnett/graphics/style.css
+++ b/SITnett/graphics/style.css
@@ -756,7 +756,7 @@ select{
 		position: absolute;
 		height: min-content;
 		top: 0;
-
+		transition: none;
 		display: none;
 		margin-left: 35%;
 	}


### PR DESCRIPTION
Det var to feil som gjorde at vi ikke fikk oppskriften vi ønsket på desktop:
1. Når siden først blir lastet inn satte vi høyden på tekstinnholdet, men ikke høyden på `div`-en som inneholder både tekstinnholdet og menyen. Dette blir feil siden teksten har `position: absolute`, og dermed ikke automatisk dytter footeren ned.
2. Når det var lite eller ingen tekst (f.eks. som under _Omtale_ hos mange av produskjonene) ble høyden til den ytre `div`-en satt til `30px`, og vi får samme problem som over.
Test gjerne på et par forskjellige produksjoner og se at ting ikke er ødelagt :)