### PR TITLE
Display fixes 2

### DIFF
--- a/SITnett/SITdata/models.py
+++ b/SITnett/SITdata/models.py
@@ -227,10 +227,8 @@ class Produksjon(models.Model):
     def spilleperiode(self):
     # lager en spilleperiode-string på formen "15.–16. februar"/"15. januar – 16. februar",
     # "vår"/"høst" hvis spilledatoene er ukjente eller "UKA"/"ISFiT" hvis produksjonen er en festivalproduksjon.
-        if self.produksjonstype == 4:
-            return "UKA"
-        elif self.produksjonstype == 5:
-            return "ISFiT"
+        if self.produksjonstype in [4,5]:
+            return self.semester()
         elif self.forestillinger.count() > 1:
             forste_dato = self.forestillinger.first().tidspunkt.date()
             siste_dato = self.forestillinger.last().tidspunkt.date()

--- a/SITnett/SITnett/views.py
+++ b/SITnett/SITnett/views.py
@@ -330,11 +330,13 @@ def view_medlem_slett(request, mid):
     if not (features.TOGGLE_MEDLEMMER and features.TOGGLE_EDIT):
         return redirect('hoved')
     medlem = get_object_or_404(models.Medlem, id=mid)
+    gjengerfaringsoppslag = make_gjengerfaringsoppslag(medlem,True)
+    produksjonserfaringsoppslag = make_produksjonserfaringsoppslag(medlem)
     if (request.method == 'POST'):
         medlem.delete()
         return redirect('medlemmer')
     return render(request, 'medlemmer/medlem_slett.html', {'FEATURES': features,
-        'medlem': medlem})
+        'medlem': medlem, 'gjengerfaringsoppslag':gjengerfaringsoppslag, 'produksjonserfaringsoppslag':produksjonserfaringsoppslag})
 
 
 @permission_required('SITdata.delete_utmerkelse')
@@ -459,11 +461,11 @@ def view_produksjon_info(request, pid):
         access = 'own'
     else:
         access = 'other'
-    vervoppslag = make_produksjonsvervoppslag(produksjon)
-    titteloppslag = make_produksjonstitteloppslag(produksjon)
     produksjonstags = produksjon.produksjonstags.all()
     if produksjonstags.filter(tag="UKErevy") or produksjonstags.filter(tag="supperevy"):
         produksjonstags = produksjonstags.exclude(tag="revy")
+    vervoppslag = make_produksjonsvervoppslag(produksjon)
+    titteloppslag = make_produksjonstitteloppslag(produksjon)
     return render(request, 'produksjoner/produksjon_info.html', {'FEATURES': features, 'access': access,
         'produksjon': produksjon, 'produksjonstags': produksjonstags,
         'vervoppslag': vervoppslag, 'titteloppslag': titteloppslag})
@@ -481,6 +483,9 @@ def view_produksjon_endre(request, pid):
         ProduksjonForm = forms.ProduksjonOwnForm
     else:
         return redirect('/konto/login/?next=%s' % request.path)
+    produksjonstags = produksjon.produksjonstags.all()
+    if produksjonstags.filter(tag="UKErevy") or produksjonstags.filter(tag="supperevy"):
+        produksjonstags = produksjonstags.exclude(tag="revy")
     vervoppslag = make_produksjonsvervoppslag(produksjon)
     titteloppslag = make_produksjonstitteloppslag(produksjon)
     if request.method == 'POST':
@@ -512,7 +517,8 @@ def view_produksjon_endre(request, pid):
         anmeldelsesform = forms.AnmeldelseForm()
         erfaringsform = forms.ErfaringProdForm()
     return render(request, 'produksjoner/produksjon_endre.html', {'FEATURES': features,
-        'produksjon': produksjon, 'vervoppslag': vervoppslag, 'titteloppslag': titteloppslag,
+        'produksjon': produksjon, 'produksjonstags': produksjonstags,
+        'vervoppslag': vervoppslag, 'titteloppslag': titteloppslag,
         'produksjonsform': produksjonsform, 'forestillingsform': forestillingsform,
         'anmeldelsesform': anmeldelsesform, 'erfaringsform': erfaringsform})
 
@@ -522,11 +528,17 @@ def view_produksjon_slett(request, pid):
     if not (features.TOGGLE_PRODUKSJONER and features.TOGGLE_EDIT):
         return redirect('hoved')
     produksjon = get_object_or_404(models.Produksjon, id=pid)
+    produksjonstags = produksjon.produksjonstags.all()
+    if produksjonstags.filter(tag="UKErevy") or produksjonstags.filter(tag="supperevy"):
+        produksjonstags = produksjonstags.exclude(tag="revy")
+    vervoppslag = make_produksjonsvervoppslag(produksjon)
+    titteloppslag = make_produksjonstitteloppslag(produksjon)
     if request.method == 'POST':
         produksjon.delete()
         return redirect('produksjoner')
     return render(request, 'produksjoner/produksjon_slett.html', {'FEATURES': features,
-        'produksjon': produksjon})
+        'produksjon': produksjon, 'produksjonstags': produksjonstags,
+        'vervoppslag': vervoppslag, 'titteloppslag': titteloppslag,})
 
 
 @login_required

--- a/SITnett/SITnett/views.py
+++ b/SITnett/SITnett/views.py
@@ -72,7 +72,6 @@ def make_styrevervoppslag(ar):
     styreerfaringer = models.Erfaring.objects.filter(ar=ar).filter(verv__vervtype=1)
     if styreerfaringer.count():
         vids = styreerfaringer.values_list('verv', flat=True).distinct().order_by('verv__id')
-        print(vids)
         vervoppslag = {}
         for vid in vids:
             if vid == None:

--- a/SITnett/templates/kontakt.html
+++ b/SITnett/templates/kontakt.html
@@ -54,7 +54,7 @@
 						{% endif %}
 						{% if erfaringer.first.rolle %} ({{erfaringer.first.rolle}}){% endif %}
 						{% for erfaring in erfaringer %}
-							{% if forloop.counter > 1 %}
+							{% if not forloop.first %}
 								,&nbsp;</span><span>
 								{% if erfaring.medlem %}
 									{% if FEATURES.TOGGLE_MEDLEMMER %}
@@ -135,7 +135,7 @@
 						{% endif %}
 						{% if erfaringer.first.rolle %} ({{erfaringer.first.rolle}}){% endif %}
 						{% for erfaring in erfaringer %}
-							{% if forloop.counter > 1 %}
+							{% if not forloop.first %}
 								,&nbsp;</span><span>
 								{% if erfaring.medlem %}
 									{% if FEATURES.TOGGLE_MEDLEMMER %}

--- a/SITnett/templates/medlemmer/medlem_endre.html
+++ b/SITnett/templates/medlemmer/medlem_endre.html
@@ -31,17 +31,9 @@
 {% endblock medlem_info %}
 
 
-{% block erfaring_fjern %}
-
-	{% if perms.SITdata.delete_erfaring %}
-		<a href="{% url 'erfaring_fjern' erfaring.id %}">Fjern</a>
-	{% endif %}
-			
-{% endblock erfaring_fjern %}
-
 {% block erfaring_ny %}
-	
-	{% if perms.SITdata.add_erfaring %}	
+
+	{% if perms.SITdata.add_erfaring %}
 		<br>
 		<form action="{% url 'medlem_endre' medlem.id %}" enctype="multipart/form-data" method="post" class="form-wrapper">
 			{% csrf_token %}
@@ -55,7 +47,7 @@
 
 
 {% block utmerkelse_fjern %}
-	
+
 	{% if perms.SITdata.delete_utmerkelse %}
 		<a href="{% url 'utmerkelse_fjern' utmerkelse.id %}">Fjern</a>
 	{% endif %}

--- a/SITnett/templates/medlemmer/medlem_info.html
+++ b/SITnett/templates/medlemmer/medlem_info.html
@@ -1,14 +1,14 @@
 {% extends "meny.html" %}
 
 {% block innhold %}
-	
+
 	<div class="member-image-container">
 		{% if user.is_authenticated %}
 			{% if medlem.portrett.url %}<img src="{{medlem.portrett.url}}">{% endif %}
 			{% else %} <img src="/files/default/katt.png">
 		{% endif %}
 	</div>
-	
+
 	<div class="member-general-info">
 		{% block medlem_navn %}
 		<h2>{{medlem}}</h2>
@@ -16,10 +16,10 @@
 			{% if medlem.kallenavn %}også kjent som <b>"{{medlem.kallenavn}}"</b><br><br>{% endif %}
 		{% endif %}
 		{% endblock medlem_navn %}
-	
+
 		<p>
 		{% if medlem.status and medlem.undergjeng %}
-			{{medlem.get_status_display|capfirst}}, 
+			{{medlem.get_status_display|capfirst}},
 		{% endif %}
 		{% if medlem.undergjeng %}
 			{% if medlem.medlemstype > 1 %}
@@ -38,7 +38,7 @@
 			{% for utmerkelse in medlem.utmerkelser.all %}
 					{{utmerkelse.full_tittel|capfirst}}
 					{% block utmerkelse_fjern %}
-					
+
 					{% endblock utmerkelse_fjern %}
 					<br>
 			{% endfor %}
@@ -57,7 +57,7 @@
 				{% else %}
 					{{medlem.opptaksar}}
 				{% endif %}
-				</td> 
+				</td>
 			</tr>
 			{% endif %}
 			{% if user.is_authenticated %}
@@ -68,13 +68,13 @@
 				{% if medlem.telefon %}
 				<tr>
 				  <td><b>Telefon:</b> </td>
-				  <td>{{medlem.telefon}}</td> 
+				  <td>{{medlem.telefon}}</td>
 				</tr>
 				{% endif %}
 				{% if medlem.epost %}
 				<tr>
 				  <td><b>E-post:</b></td>
-				  <td>{{medlem.epost}}</td> 
+				  <td>{{medlem.epost}}</td>
 				</tr>
 				{% endif %}
 				<tr>
@@ -84,7 +84,7 @@
 				{% if medlem.fodselsdato %}
 				<tr>
 				<td><b>Fødselsdag:</b></td>
-				<td>{{medlem.fodselsdato}}</td> 
+				<td>{{medlem.fodselsdato}}</td>
 				</tr>
 				{% endif %}
 				<tr>
@@ -94,13 +94,13 @@
 				{% if medlem.studium %}
 				<tr>
 				  <td><b>Studium:</b></td>
-				  <td>{{medlem.studium|capfirst}}</td> 
+				  <td>{{medlem.studium|capfirst}}</td>
 				</tr>
 				{% endif %}
 				{% if medlem.jobb %}
 					<tr>
 					<td><b>Jobb:</b></td>
-					<td>{{medlem.jobb|capfirst}}</td> 
+					<td>{{medlem.jobb|capfirst}}</td>
 					</tr>
 				{% endif %}
 			{% endif %}
@@ -109,61 +109,129 @@
 		{% endblock medlem_info %}
 	</div>
 
-	{% if medlem.erfaringer.count %}
+	{% if gjengerfaringsoppslag or produksjonserfaringsoppslag %}
 		<section class="member-information">
 			<div class="member-firstDivider"></div>
-			<a class="member-categories"><h3>Erfaringer</h3></a>
+
+			{% if gjengerfaringsoppslag %}
+			<a class="member-categories"><h3>Gjengerfaringer</h3></a>
 			<div class="member-category-content">
-				{% for erfaring in medlem.erfaringer.all %}
-					{% if erfaring.verv %}
-						{% if FEATURES.TOGGLE_VERV and erfaring.verv.erfaringsoverforing and user.is_authenticated %}
-							<a href="{% url 'verv_info' erfaring.verv.id %}">
-						{% endif %}
-							{% if erfaring.produksjon.UKEtype == "UKErevy" %}
-								{% if erfaring.verv.tittel == "lysdesigner" %}
-									Lysmester
-								{% elif erfaring.verv.tittel == "videodesigner" %}
-									Videomester
-								{% else %}
-									{{erfaring.verv|capfirst}}
-								{% endif %}
-							{% elif erfaring.produksjon.UKEtype == "supperevy" %}
-								{% if erfaring.verv.tittel == "produsent" %}
-									Suppedirektør
-								{% elif erfaring.verv.tittel == "regissør" %}
-									Supperegissør
+				{% for arstall, erfaringer in gjengerfaringsoppslag.items %}
+					{% for erfaring in erfaringer %}
+						{% if forloop.first %}
+							{% if erfaring.verv %}
+								{% if FEATURES.TOGGLE_VERV and erfaring.verv.erfaringsoverforing and user.is_authenticated %}
+									<a href="{% url 'verv_info' erfaring.verv.id %}">{{erfaring.verv|capfirst}}</a>
 								{% else %}
 									{{erfaring.verv|capfirst}}
 								{% endif %}
 							{% else %}
-								{{erfaring.verv|capfirst}}
+								{{erfaring.tittel|capfirst}}
 							{% endif %}
-						{% if FEATURES.TOGGLE_VERV and erfaring.verv.erfaringsoverforing and user.is_authenticated %}
-						</a>
-						{% endif %}
-					{% else %}
-						{{erfaring.tittel|capfirst}}
-					{% endif %}
-					{% if erfaring.rolle %} ({{erfaring.rolle}}){% endif %} i 
-					{% if erfaring.produksjon %}
-						{% if FEATURES.TOGGLE_PRODUKSJONER %}
-							<a href="{% url 'produksjon_info' erfaring.produksjon.id %}">{{erfaring.produksjon}}</a>
+							{% if erfaring.rolle %} ({{erfaring.rolle}}){% endif %}
 						{% else %}
-							{{erfaring.produksjon}}
+							{% if forloop.last %} og {% else %}, {% endif %}
+							{% if erfaring.verv %}
+								{% if FEATURES.TOGGLE_VERV and erfaring.verv.erfaringsoverforing and user.is_authenticated %}
+									<a href="{% url 'verv_info' erfaring.verv.id %}">{{erfaring.verv}}</a>
+								{% else %}
+									{{erfaring.verv}}
+								{% endif %}
+							{% else %}
+								{{erfaring.tittel}}
+							{% endif %}
+							{% if erfaring.rolle %} ({{erfaring.rolle}}){% endif %}
 						{% endif %}
+					{% endfor %}
+					{% if FEATURES.TOGGLE_AR %}
+						i <a href="{% url 'ar_info' arstall %}">{{arstall}}</a>
 					{% else %}
-						{% if FEATURES.TOGGLE_AR %}
-							<a href="{% url 'ar_info' erfaring.ar %}">{{erfaring.ar}}</a>
-						{% else %}
-							{{erfaring.ar}}
-						{% endif %}
+						i {{arstall}}
 					{% endif %}
-					{% block erfaring_fjern %}
-
-					{% endblock erfaring_fjern %}
 					<br>
 				{% endfor %}
 			</div>
+			{% endif %}
+
+			{% if produksjonserfaringsoppslag %}
+			<a class="member-categories"><h3>Produksjonserfaringer</h3></a>
+			<div class="member-category-content">
+				{% for produksjon, erfaringer in produksjonserfaringsoppslag.items %}
+					{% for erfaring in erfaringer %}
+						{% if forloop.first %}
+							{% if erfaring.verv %}
+								{% if FEATURES.TOGGLE_VERV and erfaring.verv.erfaringsoverforing and user.is_authenticated %}
+									<a href="{% url 'verv_info' erfaring.verv.id %}">
+								{% endif %}
+									{% if erfaring.produksjon.UKEtype == "UKErevy" %}
+										{% if erfaring.verv.tittel == "lysdesigner" %}
+											Lysmester
+										{% elif erfaring.verv.tittel == "videodesigner" %}
+											Videomester
+										{% else %}
+											{{erfaring.verv|capfirst}}
+										{% endif %}
+									{% elif erfaring.produksjon.UKEtype == "supperevy" %}
+										{% if erfaring.verv.tittel == "produsent" %}
+											Suppedirektør
+										{% elif erfaring.verv.tittel == "regissør" %}
+											Supperegissør
+										{% else %}
+											{{erfaring.verv|capfirst}}
+										{% endif %}
+									{% else %}
+										{{erfaring.verv|capfirst}}
+									{% endif %}
+								{% if FEATURES.TOGGLE_VERV and erfaring.verv.erfaringsoverforing and user.is_authenticated %}
+								</a>
+								{% endif %}
+							{% else %}
+								{{erfaring.tittel|capfirst}}
+							{% endif %}
+							{% if erfaring.rolle %} ({{erfaring.rolle}}){% endif %}
+						{% else %}
+							{% if forloop.last %} og {% else %}, {% endif %}
+							{% if erfaring.verv %}
+								{% if FEATURES.TOGGLE_VERV and erfaring.verv.erfaringsoverforing and user.is_authenticated %}
+									<a href="{% url 'verv_info' erfaring.verv.id %}">
+								{% endif %}
+									{% if erfaring.produksjon.UKEtype == "UKErevy" %}
+										{% if erfaring.verv.tittel == "lysdesigner" %}
+											lysmester
+										{% elif erfaring.verv.tittel == "videodesigner" %}
+											videomester
+										{% else %}
+											{{erfaring.verv}}
+										{% endif %}
+									{% elif erfaring.produksjon.UKEtype == "supperevy" %}
+										{% if erfaring.verv.tittel == "produsent" %}
+											suppedirektør
+										{% elif erfaring.verv.tittel == "regissør" %}
+											supperegissør
+										{% else %}
+											{{erfaring.verv}}
+										{% endif %}
+									{% else %}
+										{{erfaring.verv}}
+									{% endif %}
+								{% if FEATURES.TOGGLE_VERV and erfaring.verv.erfaringsoverforing and user.is_authenticated %}
+								</a>
+								{% endif %}
+							{% else %}
+								{{erfaring.tittel}}
+							{% endif %}
+							{% if erfaring.rolle %} ({{erfaring.rolle}}){% endif %}
+						{% endif %}
+					{% endfor %}
+					{% if FEATURES.TOGGLE_PRODUKSJONER %}
+						i <a href="{% url 'produksjon_info' produksjon.id %}">{{produksjon}}</a>
+					{% else %}
+						i {{produksjon}}
+					{% endif %}
+					<br>
+				{% endfor %}
+			</div>
+			{% endif %}
 		</section>
 	{% endif %}
 
@@ -178,7 +246,7 @@
 
 
 	{% block medlem_nav %}
-	
+
 		{% if FEATURES.TOGGLE_EDIT %}
 			{% if user.is_authenticated %}
 				<br><br>
@@ -191,7 +259,7 @@
 				<br>
 			{% endif %}
 		{% endif %}
-	
+
 	{% endblock medlem_nav %}
 
 {% endblock innhold %}

--- a/SITnett/templates/produksjoner/produksjon_info.html
+++ b/SITnett/templates/produksjoner/produksjon_info.html
@@ -22,11 +22,9 @@
 						{{produksjon.get_produksjonstype_display}},
 					{% endif %}
 					{% if produksjon.produksjonstype == 4 or produksjon.produksjonstype == 5 %}
-						{{produksjon.semester}}
-					{% elif produksjon.spilleperiode %}
-						{{produksjon.spilleperiode|capfirst}} {{produksjon.premieredato.year}}
+						{{produksjon.spilleperiode}}
 					{% else %}
-						{{produksjon.premieredato.year}}
+						{{produksjon.spilleperiode|capfirst}} {{produksjon.premieredato.year}}
 					{% endif %}
 					</p>
 				</div>

--- a/SITnett/templates/produksjoner/produksjoner.html
+++ b/SITnett/templates/produksjoner/produksjoner.html
@@ -11,7 +11,7 @@
 		</div>
 
 		{{produksjonsform.media.js}}
-		<div class="filter-and-result-container">  
+		<div class="filter-and-result-container">
 			<div class="filter-column">
 				<button class="filter-button" onclick="filterFunction()">Filter</button>
 
@@ -28,7 +28,7 @@
 							<label>Tags</label>
 							<div style>{{produksjonsform.produksjonstags}}</div>
 						</div>
-						
+
 						<div class="filter-category">
 							<label>Forfatter</label>
 							<div>{{produksjonsform.forfatter}}</div>
@@ -42,7 +42,7 @@
 						<div class="filter-category">
 							<label>Spilleår</label>
 							<div class="year-search-container">
-								<p>Se oppsetninger mellom</p> 
+								<p>Se oppsetninger mellom</p>
 								<div>{{produksjonsform.fra_ar}} og {{produksjonsform.til_ar}}</div>
 							</div>
 						</div>
@@ -67,16 +67,14 @@
 					<a class="card" href="{% url 'produksjon_info' produksjon.id %}">
 						<img src="{{produksjon.banner.url}}" class="card-image" loading="lazy">
 						<div class="card-container">
-							<h3 class="card-title">{{produksjon.tittel}}</h3> 
+							<h3 class="card-title">{{produksjon.tittel}}</h3>
 							<div class="text-info text-strong">
 								{% if produksjon.produksjonstype == 4 or produksjon.produksjonstype == 5 %}
-									{{produksjon.semester}}
-								{% elif produksjon.spilleperiode %}
-									{{produksjon.spilleperiode|capfirst}} {{produksjon.premieredato.year}}
+									{{produksjon.spilleperiode}}
 								{% else %}
-									{{produksjon.premieredato.year}}
+									{{produksjon.spilleperiode|capfirst}} {{produksjon.premieredato.year}}
 								{% endif %}
-							</div> 
+							</div>
 						</div>
 					</a>
 					{% empty %}

--- a/SITnett/templates/produksjoner/produksjoner.html
+++ b/SITnett/templates/produksjoner/produksjoner.html
@@ -72,6 +72,9 @@
 								{% if produksjon.produksjonstype == 4 or produksjon.produksjonstype == 5 %}
 									{{produksjon.spilleperiode}}
 								{% else %}
+									{% if produksjon.produksjonstype == 2 or produksjon.produksjonstype == 3 %}
+										{{produksjon.get_produksjonstype_display}},
+									{% endif %}
 									{{produksjon.spilleperiode|capfirst}} {{produksjon.premieredato.year}}
 								{% endif %}
 							</div>


### PR DESCRIPTION
Har fiksa en del rusk og rask ved visning av data fra databasen. Blant annet:

- Medvirkende (/produksjon/) sorteres nå etter verv-id.
- Erfaringer (/medlem/) sorteres nå etter gjengerfaringer og produksjonserfaringer, og flere verv innen samme år/produksjon slås sammen på ei linje.
- AFEIer og KUP-produksjoner merkes som dette også på produksjonslista (ikke bare inne på siden).
- Noen forenklinger i koden her og der.