### PR TITLE
Nummer list view

### DIFF
--- a/SITnett/SITnett/views.py
+++ b/SITnett/SITnett/views.py
@@ -584,31 +584,27 @@ def view_anmeldelse_fjern(request, aid):
 
 def view_numre(request):
     if not features.TOGGLE_NUMRE:
-        return redirect('hoved')
-    nummerliste = models.Nummer.objects.all()
-    if request.GET:
-        nummerform = forms.NummerSearchForm(request.GET)
-        if request.GET['tittel']:
-            tittel = request.GET['tittel']
-            nummerliste = nummerliste.filter(tittel__icontains=tittel)
-        if 'produksjon' in request.GET and request.GET['produksjon'] != '':
-            produksjoner = request.GET.getlist('produksjon')
-            nummerliste = nummerliste.filter(produksjon__id__in=produksjoner)
-        if request.GET['fritekst']:
-            fritekst = request.GET['fritekst']
-            nummerliste = (nummerliste.filter(beskrivelse__icontains=fritekst) |
-                nummerliste.filter(anekdoter__icontains=fritekst) |
-                nummerliste.filter(manus__icontains=fritekst))
+        return redirect("hoved")
+    search_query = request.GET.get("query", "")
+    if search_query == "":
+        nummerliste = models.Nummer.objects.all()
     else:
-        arstall = datetime.datetime.now().year
-        nummerform = forms.NummerSearchForm()
-        produksjonsliste = models.Produksjon.objects.all()
-        produksjonsliste = produksjonsliste.filter(premieredato__year__gte=(arstall-30))
-        produksjonsliste = produksjonsliste.filter(produksjonstype=4)
-        nummerliste = nummerliste.filter(produksjon__id__in=produksjonsliste)
-            # filtrerer ut numre fra produksjoner fra de siste 10 årene som utgangspunkt.
-    return render(request, 'numre/numre.html', {'FEATURES': features,
-        'nummerliste': nummerliste, 'nummerform': nummerform})
+        nummerliste = (
+            models.Nummer.objects.filter(tittel__icontains=search_query)
+            | models.Nummer.objects.filter(produksjon__tittel__icontains=search_query)
+            | models.Nummer.objects.filter(manus__icontains=search_query)
+        )
+
+    return render(
+        request,
+        "numre/numre.html",
+        {
+            "FEATURES": features,
+            "nummerliste": nummerliste,
+            "search_query": search_query,
+        },
+    )
+
 
 
 def view_nummer_info(request, nid):

--- a/SITnett/graphics/assets/right-chevron.svg
+++ b/SITnett/graphics/assets/right-chevron.svg
@@ -1,0 +1,16 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0_2239_2032)">
+    <path d="M8.58984 16.59L13.1698 12L8.58984 7.41L9.99984 6L15.9998 12L9.99984 18L8.58984 16.59Z" fill="#A9927D" />
+    <g clip-path="url(#clip1_2239_2032)">
+      <path d="M8.58984 16.59L13.1698 12L8.58984 7.41L9.99984 6L15.9998 12L9.99984 18L8.58984 16.59Z" fill="#A9927D" />
+    </g>
+  </g>
+  <defs>
+    <clipPath id="clip0_2239_2032">
+      <rect width="24" height="24" fill="white" transform="translate(0 24) rotate(-90)" />
+    </clipPath>
+    <clipPath id="clip1_2239_2032">
+      <rect width="24" height="24" fill="white" transform="translate(0 24) rotate(-90)" />
+    </clipPath>
+  </defs>
+</svg>

--- a/SITnett/graphics/css/numre.css
+++ b/SITnett/graphics/css/numre.css
@@ -1,0 +1,116 @@
+.main-content {
+  box-sizing: border-box;
+}
+
+.numre-main-heading {
+  font-size: 1.5rem;
+  color: #2b2b2b;
+  font-weight: 700;
+  font-family: var(--sit-serif);
+  text-align: center;
+  padding: 0 18px;
+  margin: 0;
+  margin-bottom: 30px;
+}
+
+.numre-search-form {
+  padding: 0 18px;
+}
+
+.numre-search-form__label {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--gunmetal-80);
+}
+
+.numre-search-form__input {
+  appearance: none;
+  background: #fff;
+  border: 1px solid var(--secondary-text-color);
+  display: block;
+  width: 100%;
+}
+
+.nummer-wrapper {
+  padding-inline: 18px;
+}
+
+.nummer-wrapper__row {
+  display: grid;
+  grid-template-columns: 1fr 24px;
+  padding: 18px 0;
+  border-bottom: 2px solid #a48b75;
+}
+
+.nummer-wrapper__row__chevron {
+  position: relative;
+  top: 2px;
+}
+
+.nummer-wrapper__row__item-list {
+  display: none;
+}
+
+.nummer-wrapper__row__btn {
+  display: none;
+}
+
+.nummer-wrapper__row__title-wrapper {
+  font-size: var(--font-size-regular);
+}
+
+.nummer-wrapper__row__title-wrapper__title {
+  font-family: var(--sit-sans);
+  font-size: inherit;
+  font-weight: 600;
+  margin: 0;
+  margin-bottom: 3px;
+}
+
+.nummer-wrapper__row__title-wrapper__subtitle {
+  color: #4b4b4b;
+}
+
+/* Desktop styles */
+@media (min-width: 1024px) {
+  .numre-main-wrapper {
+    display: grid;
+    grid-template-columns: 224px 1fr;
+    gap: 44px;
+    max-width: 1124px;
+    margin: 0 auto;
+  }
+  
+  .numre-main-heading {
+    font-size: 2.75rem;
+    color: var(--gunmetal-80);
+  }
+
+  .nummer-wrapper__row {
+    grid-template-columns: 7fr 3fr 166px;
+  }
+
+  .nummer-wrapper__row__title-wrapper {
+    height: max-content;
+    align-self: center;
+  }
+
+  .nummer-wrapper__row__chevron {
+    display: none;
+  }
+
+  .nummer-wrapper__row__item-list {
+    display: block;
+    font-size: var(--font-size-regular);
+    list-style: none;
+  }
+
+  .nummer-wrapper__row__btn {
+    display: block;
+    align-self: center;
+    font-size: 16px;
+    padding: 12px 64px;
+    border: 1px solid var(--grullo-100);
+    border-radius: 32px;
+  }
+}

--- a/SITnett/graphics/style.css
+++ b/SITnett/graphics/style.css
@@ -17,7 +17,7 @@ body {
 	flex-direction: column;
 }
 
-content {
+.main-wrapper {
 	/* display: flex; */
 	min-height: 80vh;
 	padding-top: 20px;
@@ -187,14 +187,14 @@ content {
 	display: grid;
 	max-width: 1200px;
 	margin: auto;
-	grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     grid-auto-rows: min-content;
     grid-gap: 1.0rem 0.5rem;
     justify-content: center;
 }
 
 .production-wrapper .card-wrapper{
-	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
 }
 
 .card {

--- a/SITnett/templates/meny.html
+++ b/SITnett/templates/meny.html
@@ -10,13 +10,13 @@
 	<link rel="icon" type="image/svg" href="{% static 'assets/sit_logo_without_text.svg' %}">
 	<link rel="stylesheet" href="{% static 'style.css' %}"/>
 
-	{% block header_content %}{% endblock header_content %}
-
+	
 	<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Libre+Baskerville">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 	<script src="{% static 'js/jquery.js' %}"></script>
+	{% block header_content %}{% endblock header_content %}
 </head>
 
 <body>
@@ -60,11 +60,11 @@
 
 	</div>
 
-	<content>
+	<main class="main-wrapper">
 		{% block innhold %}
 
 		{% endblock innhold %}
-	</content>
+	</main>
 
 	<div class="footer">
 		<div class="footer-flex-wrapper">

--- a/SITnett/templates/numre/numre.html
+++ b/SITnett/templates/numre/numre.html
@@ -1,67 +1,33 @@
 {% extends "meny.html" %}
 {% load static %}
 
+{% block header_content %}
+  <link rel="stylesheet" href="{% static 'css/numre.css' %}" />
+{% endblock header_content %}
+
 {% block innhold %}
-	<head>
-		<link rel="stylesheet" href="{% static 'select2.css' %}"/>
-	</head>
-	<div class="production-wrapper">
-		<div class="title-wrapper">
-			<h2>Numre</h2>
-		</div>
-
-		{{nummerform.media.js}}
-		<div class="filter-and-result-container">
-			<div class="filter-column">
-				<button class="filter-button" onclick="filterFunction()">Filter</button>
-
-				<div id="filter-container" class="filter-hide">
-
-					<form method="get">
-
-						<div class="filter-category">
-							<label>Tittel</label>
-							<div>{{nummerform.tittel}}</div>
-						</div>
-
-						<div class="filter-category">
-							<label>Produksjon</label>
-							<div>{{nummerform.produksjon}}</div>
-						</div>
-
-						<div class="filter-category">
-							<label>Tekstsøk</label>
-							<div>{{nummerform.fritekst}}</div>
-						</div>
-
-						<input type="submit" value="Søk">
-					</form>
-				</div>
-			</div>
-
-			<div class="result-column">
-				<div class="card-wrapper">
-					{% for nummer in nummerliste %}
-					<a class="card" href="{% url 'nummer_info' nummer.id %}">
-						{% if nummer.produksjon.plakat %}
-							<img src="{{nummer.produksjon.plakat.url}}" class="card-image" loading="lazy">
-						{% else %}
-							<img src="/files/default/katter.png" class="card-image" loading="lazy">
-						{% endif %}
-						<div class="card-container">
-							<h3 class="card-title">{{nummer.tittel}}</h3>
-							<div class="font-info text-strong">
-								{{nummer.produksjon.tittel}} ({{nummer.produksjon.premieredato.year}})
-							</div>
-						</div>
-					</a>
-					{% empty %}
-						Fant ingen numre.
-					{% endfor %}
-				</div>
-
-			</div>
-		</div>
-	</div>
-	<script src="{% static "/filter_accordion.js" %}"></script>
+  <h1 class="numre-main-heading">Numre</h1>
+  <section class="numre-main-wrapper">
+    <form class="numre-search-form">
+      <label class="numre-search-form__label" for="search-query-input">Søk</label>
+      <input class="numre-search-form__input" name="query" id="search-query-input" value="{{ search_query }}">
+    </form>
+    <div class="nummer-wrapper">
+      {% for nummer in nummerliste %}
+        <a class="nummer-wrapper__row" href="{% url 'nummer_info' nummer.id %}">
+          <div class="nummer-wrapper__row__title-wrapper">
+            <h2 class="nummer-wrapper__row__title-wrapper__title">{{ nummer.tittel }}</h2>
+            <span class="nummer-wrapper__row__title-wrapper__subtitle">{{ nummer.produksjon }}</span>
+          </div>
+          <ul class="nummer-wrapper__row__item-list">
+            {% if nummer.manus %}<li>Tekst</li>{% endif %}
+            {% if nummer.noter %}<li>Noter</li>{% endif %}
+            {% if nummer.opptak.count %}<li>Opptak</li>{% endif %}
+          </ul>
+          <img class="nummer-wrapper__row__chevron" src="{% static "assets/right-chevron.svg" %}" />
+          <div class="nummer-wrapper__row__btn">Åpne</div>
+        </a>
+      {% endfor %}
+    </div>
+  </section>
 {% endblock innhold %}


### PR DESCRIPTION
Implementerer (nesten) [nytt design for nummerlisten](https://www.figma.com/file/57E0w0Jg7lcQTHcoK0cd1g/Design?node-id=2239%3A2084&t=RLCLeyBPf73hJYNS-1). Det som mangler er dropdownlisten, planen er å komme tilbake til denne senere.

Tre funksjonelle endringer er gjort i endringen av viewet:
1. De tre tekstfeltene er slått sammen til ett.
2. Vi henter nummer fra alle produksjoner, ikke bare UKErevyer
3. Vi begrenser ikke alderen på numrene som hentes.

### Mobil
<img width="375" alt="bilde" src="https://user-images.githubusercontent.com/16143117/214371569-3d3d76f8-7a8d-48a2-b21b-d535390bf194.png">

### Desktop
<img width="1348" alt="bilde" src="https://user-images.githubusercontent.com/16143117/214371519-e353bafd-8d4d-4e01-80d1-13ca91b12e44.png">

