### PR TITLE
Fix get_blesteliste

### DIFF
--- a/SITnett/SITnett/views.py
+++ b/SITnett/SITnett/views.py
@@ -12,7 +12,7 @@ features = settings.FEATURES
 
 
 def get_ar(arstall: int) -> models.Ar:
-    """Finner et gitt år, eller oppretter det hvis det ikke ligger inne i databasen."""
+    # finner et gitt år, eller oppretter det hvis det ikke ligger inne i databasen.
     if ar := models.Ar.objects.filter(pk=arstall).first():
         return ar
     ar = models.Ar(pk=arstall)
@@ -20,14 +20,12 @@ def get_ar(arstall: int) -> models.Ar:
     return ar
 
 
-
-def get_blesteliste(dag: datetime.date) -> list[models.Produksjon]:
-    """Henter ei liste over produksjoner som skal blestes på forsida."""
-    blesteliste = models.Produksjon.objects.filter(
-        blestestart__isnull=False,
-        blestestart__lte=dag
-    ).order_by("premieredato")
-    return [prod for prod in blesteliste if prod.blestestopp() >= dag]
+def get_blesteliste(dag: datetime.date):
+    # henter ei liste over produksjoner som skal blæstes på forsida.
+    blesteliste = models.Produksjon.objects.filter(blestestart__isnull=False,blestestart__lte=dag)
+    pids = [produksjon.id for produksjon in blesteliste if produksjon.blestestopp() >= dag]
+    blesteliste = blesteliste.filter(id__in=pids).order_by("premieredato")
+    return blesteliste
 
 
 def get_infotekst() -> str:


### PR DESCRIPTION
Hei!


@Erik: I den siste endringa di gjorde du sånn at get_blesteliste returnerte en liste av produksjoner i stedet for et QuerySet (Djangos innebygde oppslagstype). Dette gjorde at blæstelista på forsida slutta å fungere, fordi du ikke oppdaterte templaten 'hoved.html' til å lese den nye lista.

Jeg synes vi skal holde oss til de innebygde typene i Django, slik som QuerySet, der vi kan, så jeg endra funksjonen tilbake slik at den returnerer et QuerySet igjen.

Og så er det fint om jeg kan få se over PRer som har med backend å gjøre før de merges inn, ettersom jeg har best oversikt over backend per nå. :)


Ellers er det flott at vi er back in business! På møtet 16. mars kan vi snakke mer om forenkling og testing av koden.